### PR TITLE
fix: image width style

### DIFF
--- a/packages/example/index.html
+++ b/packages/example/index.html
@@ -17,7 +17,7 @@
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <search-modal baseUrl="https://ryanc.cc"></search-modal>
+    <search-modal baseUrl="http://127.0.0.1:8090"></search-modal>
     <search-form baseUrl="http://127.0.0.1:8090"></search-form>
     <button id="btn">点开</button>
     <script>

--- a/packages/search-widget/src/search-form.ts
+++ b/packages/search-widget/src/search-form.ts
@@ -297,6 +297,10 @@ export class SearchForm extends LitElement {
         margin: 0;
       }
 
+      .search-form__result-item-content img {
+        width: 50%;
+      }
+
       .search-form__commands {
         border-top-width: 1px;
         border-color: var(--color-form-divider);


### PR DESCRIPTION
修复摘要中图片的宽度样式，防止溢出。

<img width="1059" alt="图片" src="https://github.com/halo-dev/plugin-search-widget/assets/21301288/86f5e04e-16d9-4618-8ccf-dfea396a2a77">

Fixes #21 

```release-note
修复摘要中图片的宽度样式，防止溢出。
```