### PR TITLE
refactor: improve line height style for search results

### DIFF
--- a/packages/search-widget/src/search-form.ts
+++ b/packages/search-widget/src/search-form.ts
@@ -170,7 +170,7 @@ export class SearchForm extends LitElement {
             ? 'text-white'
             : 'text-muted'}"
         ></span>
-        <div class="flex-1 space-y-1 min-w-0">
+        <div class="flex-1 space-y-1.5 min-w-0">
           <h2
             class="text-sm font-medium ${this.selectedIndex === index
               ? 'text-white'
@@ -181,7 +181,7 @@ export class SearchForm extends LitElement {
           ${hit.description
             ? html`
                 <p
-                  class="text-xs ${this.selectedIndex === index
+                  class="text-xs leading-6 ${this.selectedIndex === index
                     ? 'text-white/90'
                     : 'text-muted'}"
                 >


### PR DESCRIPTION
优化搜索结果的行高样式。

before:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/12250d9e-a7b1-4a4b-8e98-857fa4e2ed84">

after:

<img width="621" alt="image" src="https://github.com/user-attachments/assets/43b9c323-1d29-4c47-85b9-79eef0d08f8b">

/kind improvement

```release-note
优化搜索结果的行高样式。
```